### PR TITLE
Résolution via l'adresse IP publique

### DIFF
--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -9,7 +9,7 @@ node_name               chef_user
 client_key              "#{File.dirname(__FILE__)}/#{chef_user}.pem"
 
 #chef_server_url         'https://chef.zone-flight.local/organizations/zone-flight/'
-chef_server_url         'https://172.16.16.18/organizations/zone-flight/nodes'
+chef_server_url         'https://163.5.245.201/organizations/zone-flight/'
 ssl_verify_mode         :verify_none
 
 cache_type              'BasicFile'


### PR DESCRIPTION
- Modification du knife.rb afin de résoudre l'adresse de chef-server via l'IP et non DNS (car non fonctionnelle)